### PR TITLE
Jelly bean

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdk minApi
         targetSdk targetApi
         versionCode 20
-        versionName "v2.9.4"
+        versionName "v2.9.4-jellybean"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
     }

--- a/app/src/main/java/com/vectras/vm/SplashActivity.java
+++ b/app/src/main/java/com/vectras/vm/SplashActivity.java
@@ -352,7 +352,7 @@ public class SplashActivity extends AppCompatActivity implements Runnable {
         } else {
             startActivity(new Intent(this, SetupQemuActivity.class));
             //For Android 14+
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            if (Build.VERSION.SDK_INT >= 34) {
                 MainSettingsManager.setVmUi(this, "VNC");
             }
         }

--- a/app/src/main/java/com/vectras/vm/VectrasApp.java
+++ b/app/src/main/java/com/vectras/vm/VectrasApp.java
@@ -444,16 +444,16 @@ public class VectrasApp extends Application {
 		} else {
 			if (request) {
 				AlertDialog alertDialog = new AlertDialog.Builder(activity, R.style.MainDialogTheme).create();
-				alertDialog.setTitle(activity.getString(R.string.allow_permissions));
-				alertDialog.setMessage(activity.getString(R.string.you_need_to_grant_permission_to_access_the_storage_before_use));
+				alertDialog.setTitle(activity.getResources().getString(R.string.allow_permissions));
+				alertDialog.setMessage(activity.getResources().getString(R.string.you_need_to_grant_permission_to_access_the_storage_before_use));
 				alertDialog.setCancelable(false);
-				alertDialog.setButton(DialogInterface.BUTTON_POSITIVE, getContext().getString(R.string.allow), new DialogInterface.OnClickListener() {
+				alertDialog.setButton(DialogInterface.BUTTON_POSITIVE, activity.getResources().getString(R.string.allow), new DialogInterface.OnClickListener() {
 					public void onClick(DialogInterface dialog, int which) {
 						if (activity.shouldShowRequestPermissionRationale(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
 							Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
 							intent.setData(Uri.parse("package:" + activity.getPackageName()));
 							activity.startActivity(intent);
-							Toast.makeText(activity, R.string.find_and_allow_access_to_storage_in_settings, Toast.LENGTH_LONG).show();
+							Toast.makeText(activity, activity.getResources().getString(R.string.find_and_allow_access_to_storage_in_settings), Toast.LENGTH_LONG).show();
 						} else {
 							ActivityCompat.requestPermissions(activity, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, 1000);
 						}

--- a/app/src/main/java/com/vectras/vterm/Terminal.java
+++ b/app/src/main/java/com/vectras/vterm/Terminal.java
@@ -3,6 +3,7 @@ package com.vectras.vterm;
 import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
@@ -27,6 +28,7 @@ import com.vectras.qemu.MainVNCActivity;
 import com.vectras.vm.MainActivity;
 import com.vectras.vm.MainService;
 import com.vectras.vm.R;
+import com.vectras.vm.SplashActivity;
 import com.vectras.vm.VectrasApp;
 
 public class Terminal {
@@ -62,6 +64,58 @@ public class Terminal {
     private void showDialog(String message, Activity activity, String usercommand) {
         if (!usercommand.contains("qemu-system") || message.contains("Killed"))
             return;
+        //Error code: PROOT_IS_MISSING_0
+        if (message.contains("proot\": error=2,")) {
+            AlertDialog alertDialog = new AlertDialog.Builder(activity, R.style.MainDialogTheme).create();
+            alertDialog.setTitle(activity.getResources().getString(R.string.problem_has_been_detected));
+            alertDialog.setMessage(activity.getResources().getString(R.string.error_PROOT_IS_MISSING_0));
+            alertDialog.setCancelable(false);
+            alertDialog.setButton(DialogInterface.BUTTON_POSITIVE, activity.getResources().getString(R.string.continuetext), new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int which) {
+                    MainActivity.isActivate = false;
+                    VectrasApp.deleteDirectory(activity.getFilesDir().getAbsolutePath() + "/data");
+                    VectrasApp.deleteDirectory(activity.getFilesDir().getAbsolutePath() + "/distro");
+                    VectrasApp.deleteDirectory(activity.getFilesDir().getAbsolutePath() + "/usr");
+                    Intent intent = new Intent();
+                    intent.setClass(activity, SplashActivity.class);
+                    activity.startActivity(intent);
+                    activity.finish();
+                    return;
+                }
+            });
+            alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE, activity.getResources().getString(R.string.cancel), new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int which) {
+
+                }
+            });
+            alertDialog.show();
+            return;
+        } else if (message.contains(") exists") && message.contains("drive with bus")) {
+            //Error code: DRIVE_INDEX_0_EXISTS
+            VectrasApp.oneDialog(activity.getResources().getString(R.string.problem_has_been_detected), activity.getResources().getString(R.string.error_DRIVE_INDEX_0_EXISTS), true, false, activity);
+            return;
+        } else if (message.contains("gtk initialization failed") || message.contains("x11 not available")) {
+            //Error code: X11_NOT_AVAILABLE
+            AlertDialog alertDialog = new AlertDialog.Builder(activity, R.style.MainDialogTheme).create();
+            alertDialog.setTitle(activity.getResources().getString(R.string.problem_has_been_detected));
+            alertDialog.setMessage(activity.getResources().getString(R.string.error_X11_NOT_AVAILABLE));
+            alertDialog.setCancelable(false);
+            alertDialog.setButton(DialogInterface.BUTTON_POSITIVE, activity.getResources().getString(R.string.continuetext), new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int which) {
+                    MainSettingsManager.setVmUi(activity, "VNC");
+                    VectrasApp.oneDialog(activity.getResources().getString(R.string.done), activity.getResources().getString(R.string.switched_to_VNC), true, false, activity);
+                    return;
+                }
+            });
+            alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE, activity.getResources().getString(R.string.cancel), new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int which) {
+
+                }
+            });
+            alertDialog.show();
+            return;
+        }
+
         AlertDialog dialog = new AlertDialog.Builder(activity, R.style.MainDialogTheme).create();
         dialog.setTitle("Execution Result");
         dialog.setMessage(message);

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -362,6 +362,10 @@
     <string name="want_to_learn_more_about_qemu">هل تريد أن تتعلم المزيد عن QEMU؟</string>
     <string name="file_format_is_not_supported">قد لا تعمل الأشياء لأن تنسيق الملف غير مدعوم. هل تريد المتابعة؟</string>
     <string name="you_cannot_use_IDE_hard_drive_type_with_ARM64">لا يمكنك استخدام نوع محرك الأقراص الثابتة IDE مع ARM64. إذا تابعت، فسيتم استخدام نوع محرك الأقراص الثابتة الافتراضي.</string>
+    <string name="error_PROOT_IS_MISSING_0">النظام لا يعمل، الملفات الضرورية مفقودة. قد تكون هذه المشكلة ناجمة عن إعداد غير صحيح. هل تريد تجربة الإعداد مرة أخرى؟ رمز الخطأ: PROOT_IS_MISSING_0.</string>
+    <string name="error_DRIVE_INDEX_0_EXISTS">حدث خطأ ولم تتمكن الآلة الافتراضية من بدء التشغيل. هناك محركان أو أكثر لا يمكن توصيلهما بنفس الفتحة. يرجى التحقق من إعدادات الآلة الافتراضية والتأكد من عدم توصيل جميع المحركات بنفس الفتحة. رمز الخطأ: DRIVE_INDEX_0_EXISTS.</string>
+    <string name="error_X11_NOT_AVAILABLE">حدث خطأ ولا يمكن بدء تشغيل الجهاز الظاهري. X11 لا يعمل. نوصيك بالتبديل إلى VNC. هل تريد التبديل إلى VNC؟ رمز الخطأ: X11_NOT_AVAILABLE.</string>
+    <string name="switched_to_VNC">تم التحويل إلى VNC. يمكنك محاولة تشغيل الجهاز الظاهري مرة أخرى الآن.</string>
 
     <!--======================TERMUX STRINGS====================-->
     <string name="application_name">Vterm</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="app_name">Vectras VM</string>
     
     <!--======================VECTRAS STRINGS====================-->
-    <string name="app_version" translatable="false">v2.9.4</string>
+    <string name="app_version" translatable="false">v2.9.4 (Jelly bean)</string>
     <string name="qemu_version" translatable="false">Stable</string>
     <string name="str_home">Home</string>
     <string name="str_logger">Logger</string>
@@ -364,7 +364,11 @@
     <string name="want_to_learn_more_about_qemu">Want to learn more about QEMU?</string>
     <string name="file_format_is_not_supported">Things may not work because the file format is not supported. Do you want to continue?</string>
     <string name="you_cannot_use_IDE_hard_drive_type_with_ARM64">You cannot use IDE hard drive type with ARM64. If you continue, the default hard drive type will be used.</string>
-    
+    <string name="error_PROOT_IS_MISSING_0">The system is not working, necessary files are missing. This problem may be caused by incorrect setup. Do you want to try the setup again? Error code: PROOT_IS_MISSING_0.</string>
+    <string name="error_DRIVE_INDEX_0_EXISTS">An error occurred and the virtual machine cannot start. There are two or more drives that cannot be plugged into the same slot. Please check your virtual machine settings and make sure all drives are not plugged into the same slot. Error code: DRIVE_INDEX_0_EXISTS.</string>
+    <string name="error_X11_NOT_AVAILABLE">An error occurred and the virtual machine cannot start. X11 is not working. We recommend you switch to VNC. Do you want to switch to VNC? Error code: X11_NOT_AVAILABLE.</string>
+    <string name="switched_to_VNC">Switched to VNC. You can try running the virtual machine again now.</string>
+
     <!--======================TERMUX STRINGS====================-->
     <string name="application_name">Vterm</string>
     <string name="shared_user_label">Vterm user</string>

--- a/web/data/UpdateConfig.json
+++ b/web/data/UpdateConfig.json
@@ -1,8 +1,8 @@
 {
     "versionCode":"20",
-    "versionName":"v2.9.4",
+    "versionName":"v2.9.4,v2.9.4-jellybean",
     "size": "60 MB",
     "url": "https://github.com/xoureldeen/Vectras-VM-Android/releases/v2.9.4",
-    "Message": "<h2>v2.9.4</h2><ul><li>Now you can change locale in app settings.</li><li>Now you can access x11 settings.</li><li>New button to set full screen in x11 display.</li><li>Enhanced UI.</li><li>Chinese language by <a href=\"https://github.com/adk23333\" target=\"_blank\">@adk23333</a></li></ul><br><br>New updates are live!"
+    "Message": "<h2>v2.9.4</h2><ul><li>Now you can change locale in app settings.</li><li>Now you can access x11 settings.</li><li>New button to set full screen in x11 display.</li><li>Enhanced UI.</li><li>Chinese language by <a href=\"https://github.com/adk23333\" target=\"_blank\">@adk23333</a></li></ul><br><br>New updates are live!",
     "cancellable": true
 }


### PR DESCRIPTION
- Fixed Vectras VM not responding on Android 14+.
- Added dialog suggesting switching to VNC if X11 is not working.
- Added dialog suggesting resetting Vectras VM when proot is not working.
- Added error dialog that multiple drives cannot be plugged into the same slot.